### PR TITLE
fix: :bug: error: Fix incorrect positional formatter index in derive ChunkSizeOutOfRange error macro

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -53,7 +53,7 @@ pub enum BundlrError {
     #[error("Tx status not confirmed")]
     TxStatusNotConfirmed,
 
-    #[error("Chunk size out of allowed range: {0} - {0}")]
+    #[error("Chunk size out of allowed range: {0} - {1}")]
     ChunkSizeOutOfRange(u64, u64),
 
     #[error("Error posting chunk: {0}")]


### PR DESCRIPTION
This PR fixes a formatting issue with the derived error for ChunkSizeOutOfRange, where the lower bound was included in the message twice instead of the lower and upper bound.