### PR TITLE
refactor sign_transaction for multiple threads context,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 dist
 /res/gen_bundles/bundle*
 bundles.js
+.idea

--- a/src/deep_hash.rs
+++ b/src/deep_hash.rs
@@ -12,7 +12,7 @@ use futures::{Stream, TryStream, TryStreamExt};
 
 pub enum DeepHashChunk<'a> {
     Chunk(Bytes),
-    Stream(&'a mut Pin<Box<dyn Stream<Item = anyhow::Result<Bytes>>>>),
+    Stream(&'a mut Pin<Box<dyn Stream<Item = anyhow::Result<Bytes>> + Send>>),
     Chunks(Vec<DeepHashChunk<'a>>),
 }
 
@@ -60,7 +60,7 @@ pub async fn deep_hash(chunk: DeepHashChunk<'_>) -> Result<Bytes, BundlrError> {
     }
 }
 
-#[async_recursion(?Send)]
+#[async_recursion]
 pub async fn deep_hash_chunks(
     chunks: &mut Vec<DeepHashChunk<'_>>,
     acc: Bytes,


### PR DESCRIPTION
Hey guys!

JFYI:
We are using the Irys SDK within the Reth ExEx to sign transactions and send data to Arweave. One of the requirements is that the ExEx function should return a future that implements the Send trait.
https://reth.rs/docs/reth/builder/struct.WithLaunchContext.html#method.install_exex

I made some changes in types annotations and #[async_recursion]

Also maybe there were a specific reason for using #[async_recursion(?Send)] in the original implementation?
Could you let me know if there are any concerns? Thx!
