### PR TITLE
ANS-104 Indexer CLI for Arweave Network

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod verify;
 
 pub use bundlr::{Bundlr, BundlrBuilder};
 pub use signers::Signer;
-pub use transaction::bundlr::BundlrTx;
+pub use transaction::bundlr::{BundlrTx, DataItem};
 pub use verify::Verifier;
 
 #[cfg(feature = "arweave")]

--- a/src/transaction/bundlr.rs
+++ b/src/transaction/bundlr.rs
@@ -14,13 +14,13 @@ use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::fs::File;
 use std::pin::Pin;
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize)]
 pub struct TagBytes {
     pub name: Vec<u8>,
     pub value: Vec<u8>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize)]
 pub struct DataItem {
     pub signature_type: u8,
     pub signature: Vec<u8>,

--- a/src/transaction/bundlr.rs
+++ b/src/transaction/bundlr.rs
@@ -14,6 +14,11 @@ use crate::index::{Config, SignerMap};
 use crate::signers::Signer;
 use crate::tags::{AvroDecode, AvroEncode, Tag};
 use crate::utils::read_offset;
+#[derive(Debug)]
+pub struct TagBytes {
+    pub name: Vec<u8>,
+    pub value: Vec<u8>,
+}
 
 #[derive(Debug)]
 pub struct DataItem {
@@ -24,7 +29,7 @@ pub struct DataItem {
     pub anchor: Option<Vec<u8>>,
     pub number_of_tags: u64,
     pub number_of_tag_bytes: u64,
-    pub tags: Vec<Tag>,
+    pub tags: Vec<TagBytes>,
     pub data: Vec<u8>,
 }
 
@@ -52,6 +57,11 @@ impl From<BundlrTx> for DataItem {
         };
         let target = (!tx.target.is_empty()).then(|| tx.target.clone());
         let anchor = (!tx.anchor.is_empty()).then(|| tx.anchor.clone());
+        let tags = tx.tags.iter().map(|t| TagBytes {
+            name: t.name.clone().into_bytes(),
+            value: t.value.clone().into_bytes(),
+        }).collect();
+
         DataItem {
             signature_type: tx.signature_type as u8,
             signature: tx.signature,
@@ -60,7 +70,7 @@ impl From<BundlrTx> for DataItem {
             anchor,
             number_of_tags: tx.tags.len() as u64,
             number_of_tag_bytes: tx.tags.encode().unwrap().len() as u64,
-            tags: tx.tags,
+            tags,
             data,
         }
     }

--- a/src/transaction/bundlr.rs
+++ b/src/transaction/bundlr.rs
@@ -15,6 +15,19 @@ use crate::signers::Signer;
 use crate::tags::{AvroDecode, AvroEncode, Tag};
 use crate::utils::read_offset;
 
+#[derive(Debug)]
+pub struct DataItem {
+    pub signature_type: u8,
+    pub signature: Vec<u8>,
+    pub owner: Vec<u8>,
+    pub target: Option<Vec<u8>>,
+    pub anchor: Option<Vec<u8>>,
+    pub number_of_tags: u64,
+    pub number_of_tag_bytes: u64,
+    pub tags: Vec<Tag>,
+    pub data: Vec<u8>,
+}
+
 enum Data {
     None,
     Bytes(Vec<u8>),
@@ -29,6 +42,28 @@ pub struct BundlrTx {
     anchor: Vec<u8>,
     tags: Vec<Tag>,
     data: Data,
+}
+
+impl From<BundlrTx> for DataItem {
+    fn from(tx: BundlrTx) -> Self {
+        let data = match tx.data {
+            Data::Bytes(b) => b,
+            _ => vec![],
+        };
+        let target = (!tx.target.is_empty()).then(|| tx.target.clone());
+        let anchor = (!tx.anchor.is_empty()).then(|| tx.anchor.clone());
+        DataItem {
+            signature_type: tx.signature_type as u8,
+            signature: tx.signature,
+            owner: tx.owner,
+            target,
+            anchor,
+            number_of_tags: tx.tags.len() as u64,
+            number_of_tag_bytes: tx.tags.encode().unwrap().len() as u64,
+            tags: tx.tags,
+            data,
+        }
+    }
 }
 
 impl BundlrTx {

--- a/src/transaction/bundlr.rs
+++ b/src/transaction/bundlr.rs
@@ -14,13 +14,13 @@ use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::fs::File;
 use std::pin::Pin;
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TagBytes {
     pub name: Vec<u8>,
     pub value: Vec<u8>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DataItem {
     pub signature_type: u8,
     pub signature: Vec<u8>,


### PR DESCRIPTION
This PR implements a command-line tool that indexes an ANS-104 bundle from the Arweave network and outputs a parsed array to a file. The CLI is built in Rust and follows the ANS-104 specification. The key feature is that users can pass a bundle transaction ID, parse the bundle, and then output the parsed data either to a JSON file or print it to the terminal.

CLI Commands:

- print-json: Print the contents of a JSON file to the terminal with optional --print-data flag to include data content.
- fetch: Fetch and parse an ANS-104 bundle using a transaction ID. By default, the parsed data is saved to a JSON file. Use --print-terminal to print the data to the terminal instead, with an option to include data via --print-data.

