### PR TITLE
fix: file uploading

### DIFF
--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -1,11 +1,10 @@
-use std::{path::PathBuf, str::FromStr};
-
 use bundlr_sdk::{bundlr::BundlrBuilder, currency::solana::SolanaBuilder, error::BundlrError};
 use reqwest::Url;
+use std::{path::PathBuf, str::FromStr};
 
 #[tokio::main]
 async fn main() -> Result<(), BundlrError> {
-    let url = Url::parse("https://node1.bundlr.network").unwrap();
+    let url = Url::parse("https://uploader.irys.xyz").unwrap();
     let currency = SolanaBuilder::new().wallet(
         "kNykCXNxgePDjFbDWjPNvXQRa8U12Ywc19dFVaQ7tebUj3m7H4sF4KKdJwM7yxxb3rqxchdjezX9Szh8bLcQAjb")
         .build()
@@ -20,7 +19,7 @@ async fn main() -> Result<(), BundlrError> {
     let file = PathBuf::from_str("res/test_image.jpg").unwrap();
     let res = bundlr.upload_file(file).await;
     match res {
-        Ok(()) => println!("[ok]"),
+        Ok(res) => println!("Uploaded to  https://uploader.irys.xyz/tx/{}", &res.id),
         Err(err) => println!("[err] {}", err),
     }
     Ok(())

--- a/src/client/upload.rs
+++ b/src/client/upload.rs
@@ -46,7 +46,7 @@ pub async fn run_upload(
             let sig = bundlr.sign_transaction(&mut tx).await;
             assert!(sig.is_ok());
             match bundlr.send_transaction(tx).await {
-                Ok(res) => Ok(format!("File {} uploaded: {}", file_path, res)),
+                Ok(res) => Ok(format!("File {} uploaded: {:?}", file_path, res)),
                 Err(err) => Err(BundlrError::UploadError(err.to_string())),
             }
         }
@@ -62,7 +62,7 @@ pub async fn run_upload(
             let sig = bundlr.sign_transaction(&mut tx).await;
             assert!(sig.is_ok());
             match bundlr.send_transaction(tx).await {
-                Ok(res) => Ok(format!("File {} uploaded: {}", file_path, res)),
+                Ok(res) => Ok(format!("File {} uploaded: {:?}", file_path, res)),
                 Err(err) => Err(BundlrError::UploadError(err.to_string())),
             }
         }
@@ -78,7 +78,7 @@ pub async fn run_upload(
             let sig = bundlr.sign_transaction(&mut tx).await;
             assert!(sig.is_ok());
             match bundlr.send_transaction(tx).await {
-                Ok(res) => Ok(format!("File {} uploaded: {}", file_path, res)),
+                Ok(res) => Ok(format!("File {} uploaded: {:?}", file_path, res)),
                 Err(err) => Err(BundlrError::UploadError(err.to_string())),
             }
         }


### PR DESCRIPTION
This PR:
- fixes the upload example & upload_file method
- Adds an explicit UploadReponse struct for the response returned by bundlers for a successful upload